### PR TITLE
Deal with one uesr logged into multiple terminals

### DIFF
--- a/autoxkbmap
+++ b/autoxkbmap
@@ -9,7 +9,7 @@ detect_display()
 	for X in /tmp/.X11-unix/X*; do
 		## get user owning the socket
 		D="${X##/tmp/.X11-unix/X}"
-		user=$(who | awk -vD="$D" '$5 ~ "\\(:"D"\\)$" {print $1}')
+		user=$(who | awk -vD="$D" '$5 ~ "\\(:"D"\\)$" {print $1}' | head -n1)
 		## run autoxbkmap for that user (if the file is executable)
 		if [ x"${user}" != x"" ] && [ -x "/home/${user}/.config/autoxkbmap" ]; then
 			export DISPLAY=":$D"


### PR DESCRIPTION
Consider the following:

```[0]eilenberg:~/tmp/autoxkbmap% who
thomas   tty7         2019-07-06 16:12 (:0)
thomas   pts/0        2019-07-06 16:12 (:0)
thomas   pts/1        2019-07-06 18:13 (:0)
```

The original code sets `user` to `thomas thomas thomas` which prevents corrent execution of the rest of the script.