### PR TITLE
Get the user's home directory from the passwd file

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=udev-autoxkbmap
 pkgver=2
-pkgrel=1
+pkgrel=2
 pkgdesc='Udev rules to run autoxkbmap after usb keyboard hotplug.'
 arch=(any)
 url='TODO'
@@ -29,6 +29,6 @@ package() {
 }
 
 sha256sums=('60bbe2a2e830ef015116be833ca9f619895381a54dc6cea835e2c41e2ccb709e'
-            '2db5a9a576a0d98512e8784bc9935d4f1a767792473fce4165139be4795bc887'
+            'fa7ce174dc7919cfd90d7f0648e4959ce1d28d96a93a588cd97cbed86fdbb9d1'
             'a1a0d875aa0f76eb22d434f495571cf429ad0e068b1baa402f9f88abccb427f4'
             '13de323c7591cca8c4762a8944f45787390730305da10516fac5f64b5e8ee13c')

--- a/autoxkbmap
+++ b/autoxkbmap
@@ -10,8 +10,9 @@ detect_display()
 		## get user owning the socket
 		D="${X##/tmp/.X11-unix/X}"
 		user=$(who | awk -vD="$D" '$5 ~ "\\(:"D"\\)$" {print $1}')
+		home=$(getent passwd $user | cut -d: -f6)
 		## run autoxbkmap for that user (if the file is executable)
-		if [ x"${user}" != x"" ] && [ -x "/home/${user}/.config/autoxkbmap" ]; then
+		if [ x"${user}" != x"" ] && [ -x "${home}/.config/autoxkbmap" ]; then
 			export DISPLAY=":$D"
 			echo "running autoxkbmap for ${user} on display ${DISPLAY}"
 			/bin/su -c "/usr/bin/autoxkbmap --change" "${user}"


### PR DESCRIPTION
Some users will have home directories not rooted in /home; e.g. /u, or
under /var in some configurations.  Use the passwd file to lookup the
home directory.

In the case that the user doesn't have a home directory (e.g. system
user; although how they have an X session I do not know), the executable
check will be on the file `/.config/autoxkbmap`, which is unlikely to
exist.